### PR TITLE
Changes in fuguecli require greater access control

### DIFF
--- a/fugue_user_iam.json
+++ b/fugue_user_iam.json
@@ -57,6 +57,15 @@
             "Resource": [
                 "*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:Query"
+            ],
+            "Resource": [
+                "*"
+            ]
         }
     ]
 }

--- a/fugue_user_iam.json
+++ b/fugue_user_iam.json
@@ -64,7 +64,7 @@
                 "dynamodb:Query"
             ],
             "Resource": [
-                "*"
+                "arn:aws:dynamodb:us-east-1:*:table/fugue-cli-responses"
             ]
         }
     ]


### PR DESCRIPTION
dynamodb:Query needs to be added otherwise
```
fugue status
[ ERROR ] There was a problem executing this command.
   Reason: An error occurred (AccessDeniedException) when calling the Query operation: User: arn:aws:iam::877453989326:user/rbac_user_0 is not authorized to perform: dynamodb:Query on resource: arn:aws:dynamodb:us-east-1:877453989326:table/fugue-cli-responses
```
for fuguecli versions 1.0.2-1936 and onwards