### PR TITLE
New permissions for 2017.01.20 Fugue release

### DIFF
--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -55,8 +55,7 @@
                 "dynamodb:CreateTable",
                 "dynamodb:DeleteTable",
                 "dynamodb:DescribeTable",
-                "dynamodb:ListTables",
-                "dynamodb:Query"
+                "dynamodb:ListTables"
             ],
             "Resource": [
                 "*"

--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -55,7 +55,8 @@
                 "dynamodb:CreateTable",
                 "dynamodb:DeleteTable",
                 "dynamodb:DescribeTable",
-                "dynamodb:ListTables"
+                "dynamodb:ListTables",
+                "dynamodb:Query"
             ],
             "Resource": [
                 "*"
@@ -101,7 +102,8 @@
                 "ec2:DetachInternetGateway",
                 "ec2:DisassociateRouteTable",
                 "ec2:ModifyVpcAttribute",
-                "ec2:RevokeSecurityGroupEgress"
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress"
             ],
             "Resource": [
                 "*"
@@ -154,7 +156,9 @@
                 "s3:CreateBucket",
                 "s3:ListBucket",
                 "s3:PutObject",
-                "s3:GetObject"
+                "s3:GetObject",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteObject"
             ],
             "Resource": [
                 "*"

--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -202,7 +202,9 @@
             "Sid": "Stmt1484751364000",
             "Effect": "Allow",
             "Action": [
-                "kms:ListAliases"
+                "kms:ListAliases",
+                "kms:GenerateDataKeyWithoutPlaintext",
+                "kms:Decrypt"
             ],
             "Resource": [
                 "*"

--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -68,6 +68,7 @@
                 "ec2:AssociateRouteTable",
                 "ec2:AttachInternetGateway",
                 "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
                 "ec2:CreateInternetGateway",
                 "ec2:CreateRoute",
                 "ec2:CreateRouteTable",
@@ -151,7 +152,9 @@
             "Effect": "Allow",
             "Action": [
                 "s3:CreateBucket",
-                "s3:ListBucket"
+                "s3:ListBucket",
+                "s3:PutObject",
+                "s3:GetObject"
             ],
             "Resource": [
                 "*"
@@ -190,6 +193,16 @@
                 "sqs:ReceiveMessage",
                 "sqs:DeleteMessage",
                 "sqs:ListQueues"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "Stmt1484751364000",
+            "Effect": "Allow",
+            "Action": [
+                "kms:ListAliases"
             ],
             "Resource": [
                 "*"

--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -55,7 +55,8 @@
                 "dynamodb:CreateTable",
                 "dynamodb:DeleteTable",
                 "dynamodb:DescribeTable",
-                "dynamodb:ListTables"
+                "dynamodb:ListTables",
+                "dynamodb:Query"
             ],
             "Resource": [
                 "*"

--- a/fugue_user_iam.json
+++ b/fugue_user_iam.json
@@ -57,6 +57,25 @@
             "Resource": [
                 "*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:Query"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-east-1:*:table/fugue-cli-responses"
+            ]
+        },
+        {
+            "Sid": "Stmt1484850039000",
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt"
+            ],
+            "Resource": [
+                "*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Updates the `fugue-installer` and `fugue-user` IAM policies with permissions needed for the 2017.01.20 release of Fugue.