### PR TITLE
Added permissions needed to remove rbac user db from s3

### DIFF
--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -151,7 +151,9 @@
             "Effect": "Allow",
             "Action": [
                 "s3:CreateBucket",
-                "s3:ListBucket"
+                "s3:ListBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteObject"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
This change adds permissions to the administrative policy to let the uninstaller remove the S3 bucket policy and then delete some objects