### PR TITLE
append kms:CreateAlias

### DIFF
--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -208,6 +208,7 @@
             "Effect": "Allow",
             "Action": [
                 "kms:CreateKey",
+                "kms:CreateAlias",
                 "kms:ListAliases",
                 "kms:GenerateDataKeyWithoutPlaintext",
                 "kms:Decrypt"


### PR DESCRIPTION
the fugue cli requires the create alias permission for kms while doing an upgrade or installation.