### PR TITLE
Add DescribeStackEvents

### DIFF
--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -40,6 +40,7 @@
             "Action": [
                 "cloudformation:CreateStack",
                 "cloudformation:DeleteStack",
+                "cloudformation:DescribeStackEvents",
                 "cloudformation:DescribeStackResources",
                 "cloudformation:DescribeStacks",
                 "cloudformation:UpdateStack"


### PR DESCRIPTION
# What

Adds cloudformation:DescribeStackEvents. Required for `fugue uninstall`.

# Why

Updates to the CLI in the last two sprints will require this permission.