### PR TITLE
fugue support reset secret requires get, put, and delete bucket policy

### DIFF
--- a/fugue_installer_iam.json
+++ b/fugue_installer_iam.json
@@ -166,6 +166,8 @@
                 "s3:PutObject",
                 "s3:PutObjectAcl",
                 "s3:GetObject",
+                "s3:GetBucketPolicy",
+                "s3:PutBucketPolicy",
                 "s3:DeleteBucketPolicy",
                 "s3:DeleteObject"
             ],


### PR DESCRIPTION
# What
* add s3:GetBucketPolicy
* add s3:PutBucketPolicy

# Why
resetting a secret requires the ability to unlock a buckets policy.